### PR TITLE
Merchant discount delete

### DIFF
--- a/app/controllers/merchant_discounts_controller.rb
+++ b/app/controllers/merchant_discounts_controller.rb
@@ -22,6 +22,11 @@ class MerchantDiscountsController < ApplicationController
     end
   end
 
+  def destroy
+    Discount.destroy(params[:id])
+    redirect_to "/merchants/#{params[:merchant_id]}/discounts"
+  end
+
   private
   def discount_params
     params.permit(:percentage, :quantity_threshold)

--- a/app/views/merchant_discounts/index.html.erb
+++ b/app/views/merchant_discounts/index.html.erb
@@ -4,6 +4,7 @@
   <h3><%= discount.percentage %>% off</h3>
   <h3>For <%= discount.quantity_threshold %> or more items!</h3>
   <%= link_to "More Details", "/merchants/#{@merchant.id}/discounts/#{discount.id}" %>
+  <%= button_to "Delete This Discount", "/merchants/#{@merchant.id}/discounts/#{discount.id}", method: :delete %>
   <hr>
 </div>
 <% end %>

--- a/app/views/merchant_discounts/index.html.erb
+++ b/app/views/merchant_discounts/index.html.erb
@@ -3,8 +3,8 @@
 <div id="discount-<%= discount.id %>">
   <h3><%= discount.percentage %>% off</h3>
   <h3>For <%= discount.quantity_threshold %> or more items!</h3>
-  <%= link_to "More Details", "/merchants/#{@merchant.id}/discounts/#{discount.id}" %>
-  <%= button_to "Delete This Discount", "/merchants/#{@merchant.id}/discounts/#{discount.id}", method: :delete %>
+  <%= link_to "More Details", "/merchants/#{@merchant.id}/discounts/#{discount.id}" %><br>
+  <br><%= button_to "Delete This Discount", "/merchants/#{@merchant.id}/discounts/#{discount.id}", method: :delete %>
   <hr>
 </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,7 @@ Rails.application.routes.draw do
     post '/discounts', to: 'merchant_discounts#create'
     get '/discounts/new', to: 'merchant_discounts#new'
     get '/discounts/:id', to: 'merchant_discounts#show'
+    delete 'discounts/:id', to: 'merchant_discounts#destroy'
   end
 
   get '/merchants/:id/dashboard', to: 'merchants#show'

--- a/spec/features/merchant_discounts/index_spec.rb
+++ b/spec/features/merchant_discounts/index_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe 'merchant_discounts index page' do
         discount_3 = merchant_2.discounts.create!(percentage: 50, quantity_threshold: 20)
 
         visit "/merchants/#{merchant_1.id}/discounts"
-
+        
         within "#discount-#{discount_1.id}" do
           click_button "Delete This Discount"
         end

--- a/spec/features/merchant_discounts/index_spec.rb
+++ b/spec/features/merchant_discounts/index_spec.rb
@@ -49,6 +49,31 @@ RSpec.describe 'merchant_discounts index page' do
 
         expect(current_path).to eq("/merchants/#{merchant_1.id}/discounts/new")
       end
+
+      it 'next to each discount i see a link to delete it, which when clicked,
+          redirects me back to the index page where that discount is no longer listed' do
+        merchant_1 = Merchant.create!(name: "Jim's Plates")
+        discount_1 = merchant_1.discounts.create!(percentage: 20, quantity_threshold: 10)
+        discount_2 = merchant_1.discounts.create!(percentage: 30, quantity_threshold: 15)
+
+        merchant_2 = Merchant.create!(name: "John's Bars")
+        discount_3 = merchant_2.discounts.create!(percentage: 50, quantity_threshold: 20)
+
+        visit "/merchants/#{merchant_1.id}/discounts"
+
+        within "#discount-#{discount_1.id}" do
+          click_link "Delete This Discount"
+        end
+
+        expect(current_path).to eq("/merchants/#{merchant_1.id}/discounts")
+
+        expect(page).not_to have_content(discount_1.percentage)
+        expect(page).not_to have_content(discount_1.quantity_threshold)
+        expect(page).to have_content(discount_2.percentage)
+        expect(page).to have_content(discount_2.quantity_threshold)
+        expect(page).not_to have_content(discount_3.percentage)
+        expect(page).not_to have_content("For #{discount_3.quantity_threshold} or more items")
+      end
     end
   end
 end

--- a/spec/features/merchant_discounts/index_spec.rb
+++ b/spec/features/merchant_discounts/index_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe 'merchant_discounts index page' do
         visit "/merchants/#{merchant_1.id}/discounts"
 
         within "#discount-#{discount_1.id}" do
-          click_link "Delete This Discount"
+          click_button "Delete This Discount"
         end
 
         expect(current_path).to eq("/merchants/#{merchant_1.id}/discounts")


### PR DESCRIPTION
This branch accomplishes the following: 

-for each discount listed on the `merchant_discounts#index` page, adds a button to delete that discount
-if the button is clicked for some discount, then the user is redirected back to the `merchant_discounts#index` page and no longer sees that discount listed