### PR TITLE
Merchant discount edit

### DIFF
--- a/app/controllers/merchant_discounts_controller.rb
+++ b/app/controllers/merchant_discounts_controller.rb
@@ -22,6 +22,20 @@ class MerchantDiscountsController < ApplicationController
     end
   end
 
+  def edit
+    @discount = Discount.find(params[:id])
+  end
+
+  def update
+    discount = Discount.find(params[:id])
+    if discount.update(discount_params)
+      redirect_to "/merchants/#{discount.merchant_id}/discounts/#{discount.id}"
+    else
+      redirect_to "/merchants/#{discount.merchant_id}/discounts/#{discount.id}/edit"
+      flash[:invalid_data] = "Invalid Data: Percentage must be a whole number between 1 and 99 and Quantity Threshold must be a whole number greater than 1"
+    end
+  end
+
   def destroy
     Discount.destroy(params[:id])
     redirect_to "/merchants/#{params[:merchant_id]}/discounts"

--- a/app/views/merchant_discounts/edit.html.erb
+++ b/app/views/merchant_discounts/edit.html.erb
@@ -1,0 +1,13 @@
+<%= form_with url: "/merchants/#{@discount.merchant_id}/discounts/#{@discount.id}", method: :patch, local: true do |form| %>
+  <%= form.label :percentage %>
+  <%= form.number_field :percentage, value: @discount.percentage %>
+
+  <%= form.label :quantity_threshold %>
+  <%= form.number_field :quantity_threshold, value: @discount.quantity_threshold %>
+
+  <%= form.submit "Submit" %>
+<% end %>
+
+<% flash.each do |type, message| %>
+  <p><%= message %></p>
+<% end %>

--- a/app/views/merchant_discounts/show.html.erb
+++ b/app/views/merchant_discounts/show.html.erb
@@ -1,1 +1,3 @@
 <h1>Buy <%= @discount.quantity_threshold %> or more items and receive <%= @discount.percentage %>% off!</h1>
+
+<h3><%= link_to "Edit This Discount", "/merchants/#{@discount.merchant_id}/discounts/#{@discount.id}/edit" %></h3>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,8 @@ Rails.application.routes.draw do
     post '/discounts', to: 'merchant_discounts#create'
     get '/discounts/new', to: 'merchant_discounts#new'
     get '/discounts/:id', to: 'merchant_discounts#show'
+    get '/discounts/:id/edit', to: 'merchant_discounts#edit'
+    patch '/discounts/:id', to: 'merchant_discounts#update'
     delete 'discounts/:id', to: 'merchant_discounts#destroy'
   end
 

--- a/spec/features/merchant_discounts/edit_spec.rb
+++ b/spec/features/merchant_discounts/edit_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe 'merchant_discounts edit page' do
 
         visit "/merchants/#{merchant_1.id}/discounts/#{discount_1.id}/edit"
 
-        expect(page).to have_field("Percentage", with: @discount_1.percentage)
-        expect(page).to have_field("Quantity threshold", with: @discount_1.quantity_threshold)
+        expect(page).to have_field("Percentage", with: discount_1.percentage)
+        expect(page).to have_field("Quantity threshold", with: discount_1.quantity_threshold)
       end
 
       it 'when i change all of the info and click submit, i am redirected

--- a/spec/features/merchant_discounts/edit_spec.rb
+++ b/spec/features/merchant_discounts/edit_spec.rb
@@ -1,0 +1,71 @@
+RSpec.describe 'merchant_discounts edit page' do
+  describe 'as a user' do
+    describe 'when i visit my discounts edit page' do
+      it 'i see a form to edit the discount with its attributes pre-populated' do
+        merchant_1 = Merchant.create!(name: "Jim's Plates")
+        discount_1 = merchant_1.discounts.create!(percentage: 20, quantity_threshold: 10)
+        discount_2 = merchant_1.discounts.create!(percentage: 30, quantity_threshold: 15)
+        discount_3 = merchant_1.discounts.create!(percentage: 50, quantity_threshold: 35)
+
+        visit "/merchants/#{merchant_1.id}/discounts/#{discount_1.id}/edit"
+
+        expect(page).to have_field("Percentage", with: @discount_1.percentage)
+        expect(page).to have_field("Quantity threshold", with: @discount_1.quantity_threshold)
+      end
+
+      it 'when i change all of the info and click submit, i am redirected
+          back to the discounts show page and i see that the info has been updated' do
+        merchant_1 = Merchant.create!(name: "Jim's Plates")
+        discount_1 = merchant_1.discounts.create!(percentage: 20, quantity_threshold: 10)
+        discount_2 = merchant_1.discounts.create!(percentage: 30, quantity_threshold: 15)
+        discount_3 = merchant_1.discounts.create!(percentage: 50, quantity_threshold: 35)
+
+        visit "/merchants/#{merchant_1.id}/discounts/#{discount_1.id}/edit"
+
+        fill_in "Percentage", with: 10
+        fill_in "Quantity threshold", with: 5
+
+        click_button "Submit"
+
+        expect(current_path).to eq("/merchants/#{merchant_1.id}/discounts/#{discount_1.id}")
+
+        expect(page).to have_content("Buy 5 or more items and receive 10% off!")
+        expect(page).not_to have_content("Buy 10 or more items and receive 20% off!")
+      end
+
+      it 'if i input invalid data, then i am redirected back to the edit page with a flash
+          message telling me what type of data is valid' do
+        merchant_1 = Merchant.create!(name: "Jim's Plates")
+        discount_1 = merchant_1.discounts.create!(percentage: 20, quantity_threshold: 10)
+        discount_2 = merchant_1.discounts.create!(percentage: 30, quantity_threshold: 15)
+        discount_3 = merchant_1.discounts.create!(percentage: 50, quantity_threshold: 35)
+
+        visit "/merchants/#{merchant_1.id}/discounts/#{discount_1.id}/edit"
+
+        fill_in :percentage, with: 200
+        fill_in :quantity_threshold, with: 1
+
+        click_button 'Submit'
+
+        expect(page).to have_content("Invalid Data: Percentage must be a whole number between 1 and 99 and Quantity Threshold must be a whole number greater than 1")
+
+        fill_in :percentage, with: 99
+        fill_in :quantity_threshold, with: 1
+
+        click_button 'Submit'
+
+        expect(page).to have_content("Invalid Data: Percentage must be a whole number between 1 and 99 and Quantity Threshold must be a whole number greater than 1")
+
+        fill_in "Percentage", with: 10
+        fill_in "Quantity threshold", with: 5
+
+        click_button "Submit"
+
+        expect(current_path).to eq("/merchants/#{merchant_1.id}/discounts/#{discount_1.id}")
+
+        expect(page).to have_content("Buy 5 or more items and receive 10% off!")
+        expect(page).not_to have_content("Buy 10 or more items and receive 20% off!")
+      end
+    end
+  end
+end

--- a/spec/features/merchant_discounts/show_spec.rb
+++ b/spec/features/merchant_discounts/show_spec.rb
@@ -13,6 +13,19 @@ RSpec.describe 'merchant_discounts index page' do
         expect(page).not_to have_content("Buy 15 or more items and receive 30% off!")
         expect(page).not_to have_content("Buy 35 or more items and receive 50% off!")
       end
+
+      it 'i see a link to edit the discount' do
+        merchant_1 = Merchant.create!(name: "Jim's Plates")
+        discount_1 = merchant_1.discounts.create!(percentage: 20, quantity_threshold: 10)
+        discount_2 = merchant_1.discounts.create!(percentage: 30, quantity_threshold: 15)
+        discount_3 = merchant_1.discounts.create!(percentage: 50, quantity_threshold: 35)
+
+        visit "/merchants/#{merchant_1.id}/discounts/#{discount_1.id}"
+
+        click_link "Edit This Discount"
+
+        expect(current_path).to eq("/merchants/#{merchant_1.id}/discounts/#{discount_1}/edit")
+      end
     end
   end
 end

--- a/spec/features/merchant_discounts/show_spec.rb
+++ b/spec/features/merchant_discounts/show_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'merchant_discounts index page' do
 
         click_link "Edit This Discount"
 
-        expect(current_path).to eq("/merchants/#{merchant_1.id}/discounts/#{discount_1}/edit")
+        expect(current_path).to eq("/merchants/#{merchant_1.id}/discounts/#{discount_1.id}/edit")
       end
     end
   end


### PR DESCRIPTION
This branch accomplishes the following:

-adds a link to the `merchant_discounts#show` page, where the user sees a link to edit the given discount
-creates a `merchant_discounts#edit` page, where the user sees a form pre-populated with the given discount's attributes 
-the user can update the discount with new inputs as long as the data are valid
-if the user's data inputs are invalid, the user is redirected back to the edit page with a flash message indicating that they need to provide valid data; the message lists the requirements