### PR TITLE
Merchant invoice discounted revenue

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -31,7 +31,9 @@ class Invoice < ApplicationRecord
     invoice_items.sum('invoice_items.quantity * invoice_items.unit_price')
   end
 
+  
+
   def discounted_revenue
-    
+
   end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -31,7 +31,16 @@ class Invoice < ApplicationRecord
     invoice_items.sum('invoice_items.quantity * invoice_items.unit_price')
   end
 
-  
+  def apply_discounts
+    invoice_items.each do |invoice_item|
+      discounts.distinct.order(percentage: :desc).each do |discount|
+        if discount.quantity_threshold <= invoice_item.quantity && invoice_item.discount_percentage == 100
+          invoice_item.update(discount_percentage: invoice_item.discount_percentage - discount.percentage)
+        end
+      end
+    end
+    invoice_items
+  end
 
   def discounted_revenue
 

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -43,6 +43,8 @@ class Invoice < ApplicationRecord
   end
 
   def discounted_revenue
-
+    total = 0
+    apply_discounts.each {|invoice_item| total += ((invoice_item.unit_price * invoice_item.quantity) * (invoice_item.discount_percentage.to_f / 100))}
+    total
   end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -4,6 +4,7 @@ class Invoice < ApplicationRecord
   has_many :invoice_items
   has_many :items, through: :invoice_items
   has_many :merchants, through: :items
+  has_many :discounts, through: :merchants
 
   enum status: ["in progress".to_sym, :completed, :cancelled]
 
@@ -28,5 +29,9 @@ class Invoice < ApplicationRecord
 
   def total_revenue
     invoice_items.sum('invoice_items.quantity * invoice_items.unit_price')
+  end
+
+  def discounted_revenue
+    
   end
 end

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -22,4 +22,8 @@ class InvoiceItem < ApplicationRecord
   def belongs_to_merchant(merchant_id)
     item.merchant_id == merchant_id.to_i
   end
+
+  def apply_discount
+    
+  end
 end

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -1,6 +1,8 @@
 class InvoiceItem < ApplicationRecord
   belongs_to :invoice
   belongs_to :item
+  has_one :merchant, through: :item
+  has_many :discounts, through: :merchant
 
   enum status: [:pending, :packaged, :shipped]
 

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -22,8 +22,4 @@ class InvoiceItem < ApplicationRecord
   def belongs_to_merchant(merchant_id)
     item.merchant_id == merchant_id.to_i
   end
-
-  def apply_discount
-    
-  end
 end

--- a/app/views/merchant_invoices/show.html.erb
+++ b/app/views/merchant_invoices/show.html.erb
@@ -7,6 +7,7 @@ Created At: <%= @invoice.dates %>
 Customer Name: <%= @invoice.full_name %>
 <br>
 Total Revenue: $<%= "%.2f" % (@invoice.total_revenue.to_f/100).truncate(2) %>
+Revenue after Discounts: $<%= "%.2f" % (@invoice.discounted_revenue.to_f/100).truncate(2) %>
 <% @invoice.invoice_items.each do |invoice_item|%>
 <div id="item-<%= invoice_item.id %>">
   <% if invoice_item.belongs_to_merchant(@merchant.id) %>

--- a/db/migrate/20220424012244_add_discount_percentages_to_invoice_items.rb
+++ b/db/migrate/20220424012244_add_discount_percentages_to_invoice_items.rb
@@ -1,0 +1,5 @@
+class AddDiscountPercentagesToInvoiceItems < ActiveRecord::Migration[5.2]
+  def change
+    add_column :invoice_items, :discount_percentage, :integer, default: 100
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_22_005258) do
+ActiveRecord::Schema.define(version: 2022_04_24_012244) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,6 +39,7 @@ ActiveRecord::Schema.define(version: 2022_04_22_005258) do
     t.integer "status", default: 0
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer "discount_percentage", default: 100
     t.index ["invoice_id"], name: "index_invoice_items_on_invoice_id"
     t.index ["item_id"], name: "index_invoice_items_on_item_id"
   end

--- a/spec/features/merchant_invoices/show_spec.rb
+++ b/spec/features/merchant_invoices/show_spec.rb
@@ -216,7 +216,7 @@ RSpec.describe 'the merchant invoice show page' do
         @invoice_item_12 = InvoiceItem.create!(item: @item_7, invoice: @invoice_2, quantity: 10000, unit_price: 50, status: 0)
         @invoice_item_13 = InvoiceItem.create!(item: @item_8, invoice: @invoice_2, quantity: 10000, unit_price: 20, status: 0)
         @discount_1 = @merchant_1.discounts.create!(percentage: 20, quantity_threshold: 20)
-        @discount_2 = @merchant_1.discounts.create!(percentage: 30, quantity_threshold: 40)
+        @discount_2 = @merchant_1.discounts.create!(percentage: 40, quantity_threshold: 30)
 
         visit "/merchants/#{@merchant_1.id}/invoices/#{@invoice_1.id}"
       end

--- a/spec/models/invoice_item_spec.rb
+++ b/spec/models/invoice_item_spec.rb
@@ -23,49 +23,4 @@ RSpec.describe InvoiceItem, type: :model do
       expect(InvoiceItem.total_revenue).to eq(2200)
     end
   end
-
-  describe 'instance methods' do
-    describe '.apply_discount' do
-      it 'can determine if an invoice meets the threshold for any discounts and applies the highest available discount' do
-        merchant_1 = Merchant.create!(name: "Jim's Rare Guitars")
-        item_1 = merchant_1.items.create!(name: "1959 Gibson Les Paul",
-                                        description: "Tobacco Burst Finish, Rosewood Fingerboard",
-                                        unit_price: 25000)
-        item_2 = merchant_1.items.create!(name: "1954 Fender Stratocaster",
-                                        description: "Seafoam Green Finish, Maple Fingerboard",
-                                        unit_price: 10000)
-        item_3 = merchant_1.items.create!(name: "1968 Gibson SG",
-                                        description: "Cherry Red Finish, Rosewood Fingerboard",
-                                        unit_price: 400)
-        item_4 = merchant_1.items.create!(name: "1984 Gibson Les Paul",
-                                        description: "Sunburst Finish, Maple Fingerboard",
-                                        unit_price: 600)
-        item_5 = merchant_1.items.create!(name: "1991 Gibson Les Paul",
-                                        description: "Sunburst Finish, Maple Fingerboard",
-                                        unit_price: 900)
-        customer_1 = Customer.create!(first_name: "Guthrie", last_name: "Govan")
-        invoice_1 = customer_1.invoices.create!(status: 1)
-        invoice_2 = customer_1.invoices.create!(status: 0)
-        invoice_item_1 = InvoiceItem.create!(item: item_1, invoice: invoice_1, quantity: 1, unit_price: 5, status: 0)
-        invoice_item_2 = InvoiceItem.create!(item: item_2, invoice: invoice_1, quantity: 20, unit_price: 10, status: 0)
-        invoice_item_3 = InvoiceItem.create!(item: item_3, invoice: invoice_1, quantity: 10, unit_price: 20, status: 0)
-        invoice_item_4 = InvoiceItem.create!(item: item_4, invoice: invoice_1, quantity: 30, unit_price: 5, status: 0)
-        invoice_item_5 = InvoiceItem.create!(item: item_5, invoice: invoice_1, quantity: 35, unit_price: 10, status: 0)
-        discount_1 = merchant_1.discounts.create!(percentage: 20, quantity_threshold: 20)
-        discount_2 = merchant_1.discounts.create!(percentage: 30, quantity_threshold: 40)
-
-        invoice_item_1.apply_discount
-        invoice_item_2.apply_discount
-        invoice_item_3.apply_discount
-        invoice_item_4.apply_discount
-        invoice_item_5.apply_discount
-
-        expect(invoice_item_1.discount_percentage).to eq(100)
-        expect(invoice_item_2.discount_percentage).to eq(80)
-        expect(invoice_item_3.discount_percentage).to eq(100)
-        expect(invoice_item_4.discount_percentage).to eq(60)
-        expect(invoice_item_5.discount_percentage).to eq(60)
-      end
-    end
-  end
 end

--- a/spec/models/invoice_item_spec.rb
+++ b/spec/models/invoice_item_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe InvoiceItem, type: :model do
   describe 'relationships' do
     it { should belong_to(:invoice) }
     it { should belong_to(:item) }
+    it { should have_one(:merchant).through(:item)}
+    it { should have_many(:discounts).through(:merchant)}
   end
 
   describe 'class methods' do

--- a/spec/models/invoice_item_spec.rb
+++ b/spec/models/invoice_item_spec.rb
@@ -54,11 +54,17 @@ RSpec.describe InvoiceItem, type: :model do
         discount_1 = merchant_1.discounts.create!(percentage: 20, quantity_threshold: 20)
         discount_2 = merchant_1.discounts.create!(percentage: 30, quantity_threshold: 40)
 
-        expect(invoice_item_1.apply_discount.discounted_unit_price).to eq(nil)
-        expect(invoice_item_2.apply_discount.discounted_unit_price).to eq(8)
-        expect(invoice_item_3.apply_discount.discounted_unit_price).to eq(nil)
-        expect(invoice_item_4.apply_discount.discounted_unit_price).to eq(3)
-        expect(invoice_item_5.apply_discount.discounted_unit_price).to eq(6)
+        invoice_item_1.apply_discount
+        invoice_item_2.apply_discount
+        invoice_item_3.apply_discount
+        invoice_item_4.apply_discount
+        invoice_item_5.apply_discount
+
+        expect(invoice_item_1.discount_percentage).to eq(100)
+        expect(invoice_item_2.discount_percentage).to eq(80)
+        expect(invoice_item_3.discount_percentage).to eq(100)
+        expect(invoice_item_4.discount_percentage).to eq(60)
+        expect(invoice_item_5.discount_percentage).to eq(60)
       end
     end
   end

--- a/spec/models/invoice_item_spec.rb
+++ b/spec/models/invoice_item_spec.rb
@@ -23,4 +23,43 @@ RSpec.describe InvoiceItem, type: :model do
       expect(InvoiceItem.total_revenue).to eq(2200)
     end
   end
+
+  describe 'instance methods' do
+    describe '.apply_discount' do
+      it 'can determine if an invoice meets the threshold for any discounts and applies the highest available discount' do
+        merchant_1 = Merchant.create!(name: "Jim's Rare Guitars")
+        item_1 = merchant_1.items.create!(name: "1959 Gibson Les Paul",
+                                        description: "Tobacco Burst Finish, Rosewood Fingerboard",
+                                        unit_price: 25000)
+        item_2 = merchant_1.items.create!(name: "1954 Fender Stratocaster",
+                                        description: "Seafoam Green Finish, Maple Fingerboard",
+                                        unit_price: 10000)
+        item_3 = merchant_1.items.create!(name: "1968 Gibson SG",
+                                        description: "Cherry Red Finish, Rosewood Fingerboard",
+                                        unit_price: 400)
+        item_4 = merchant_1.items.create!(name: "1984 Gibson Les Paul",
+                                        description: "Sunburst Finish, Maple Fingerboard",
+                                        unit_price: 600)
+        item_5 = merchant_1.items.create!(name: "1991 Gibson Les Paul",
+                                        description: "Sunburst Finish, Maple Fingerboard",
+                                        unit_price: 900)
+        customer_1 = Customer.create!(first_name: "Guthrie", last_name: "Govan")
+        invoice_1 = customer_1.invoices.create!(status: 1)
+        invoice_2 = customer_1.invoices.create!(status: 0)
+        invoice_item_1 = InvoiceItem.create!(item: item_1, invoice: invoice_1, quantity: 1, unit_price: 5, status: 0)
+        invoice_item_2 = InvoiceItem.create!(item: item_2, invoice: invoice_1, quantity: 20, unit_price: 10, status: 0)
+        invoice_item_3 = InvoiceItem.create!(item: item_3, invoice: invoice_1, quantity: 10, unit_price: 20, status: 0)
+        invoice_item_4 = InvoiceItem.create!(item: item_4, invoice: invoice_1, quantity: 30, unit_price: 5, status: 0)
+        invoice_item_5 = InvoiceItem.create!(item: item_5, invoice: invoice_1, quantity: 35, unit_price: 10, status: 0)
+        discount_1 = merchant_1.discounts.create!(percentage: 20, quantity_threshold: 20)
+        discount_2 = merchant_1.discounts.create!(percentage: 30, quantity_threshold: 40)
+
+        expect(invoice_item_1.apply_discount.discounted_unit_price).to eq(nil)
+        expect(invoice_item_2.apply_discount.discounted_unit_price).to eq(8)
+        expect(invoice_item_3.apply_discount.discounted_unit_price).to eq(nil)
+        expect(invoice_item_4.apply_discount.discounted_unit_price).to eq(3)
+        expect(invoice_item_5.apply_discount.discounted_unit_price).to eq(6)
+      end
+    end
+  end
 end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -149,6 +149,67 @@ RSpec.describe Invoice, type: :model do
       end
     end
 
+    describe '.invoice_items_with_discounts_applied' do
+      it 'returns all invoice items with discounts applied to their discount_percentages if applicable' do
+        merchant_1 = Merchant.create!(name: "Jim's Rare Guitars")
+        item_1 = merchant_1.items.create!(name: "1959 Gibson Les Paul",
+                                        description: "Tobacco Burst Finish, Rosewood Fingerboard",
+                                        unit_price: 25000)
+        item_2 = merchant_1.items.create!(name: "1954 Fender Stratocaster",
+                                        description: "Seafoam Green Finish, Maple Fingerboard",
+                                        unit_price: 10000)
+        item_3 = merchant_1.items.create!(name: "1968 Gibson SG",
+                                        description: "Cherry Red Finish, Rosewood Fingerboard",
+                                        unit_price: 400)
+        item_4 = merchant_1.items.create!(name: "1984 Gibson Les Paul",
+                                        description: "Sunburst Finish, Maple Fingerboard",
+                                        unit_price: 600)
+        item_5 = merchant_1.items.create!(name: "1991 Gibson Les Paul",
+                                        description: "Sunburst Finish, Maple Fingerboard",
+                                        unit_price: 900)
+        item_6 = merchant_1.items.create!(name: "1993 Gibson Les Paul",
+                                        description: "Sunburst Finish, Maple Fingerboard",
+                                        unit_price: 700)
+        item_7 = merchant_1.items.create!(name: "2004 Gibson Les Paul",
+                                        description: "Sunburst Finish, Maple Fingerboard",
+                                        unit_price: 200)
+        item_8 = merchant_1.items.create!(name: "1997 Gibson Les Paul",
+                                        description: "Sunburst Finish, Maple Fingerboard",
+                                        unit_price: 100)
+        item_9 = merchant_1.items.create!(name: "1996 Gibson Les Paul",
+                                        description: "Sunburst Finish, Maple Fingerboard",
+                                        unit_price: 100)
+        item_10 = merchant_1.items.create!(name: "1975 Gibson Les Paul",
+                                        description: "Sunburst Finish, Maple Fingerboard",
+                                        unit_price: 400)
+        customer_1 = Customer.create!(first_name: "Guthrie", last_name: "Govan")
+
+        invoice_1 = customer_1.invoices.create!(status: 1)
+        invoice_2 = customer_1.invoices.create!(status: 0)
+        invoice_item_1 = InvoiceItem.create!(item: item_1, invoice: invoice_1, quantity: 1, unit_price: 5, status: 0)
+        invoice_item_2 = InvoiceItem.create!(item: item_9, invoice: invoice_1, quantity: 20, unit_price: 10, status: 0)
+        invoice_item_3 = InvoiceItem.create!(item: item_2, invoice: invoice_1, quantity: 10, unit_price: 20, status: 0)
+        invoice_item_4 = InvoiceItem.create!(item: item_4, invoice: invoice_1, quantity: 30, unit_price: 5, status: 0)
+        invoice_item_5 = InvoiceItem.create!(item: item_3, invoice: invoice_1, quantity: 35, unit_price: 10, status: 0)
+        invoice_item_6 = InvoiceItem.create!(item: item_5, invoice: invoice_1, quantity: 10, unit_price: 25, status: 0)
+        invoice_item_7 = InvoiceItem.create!(item: item_6, invoice: invoice_1, quantity: 5, unit_price: 10, status: 0)
+        invoice_item_8 = InvoiceItem.create!(item: item_8, invoice: invoice_1, quantity: 10, unit_price: 15, status: 0)
+        invoice_item_9 = InvoiceItem.create!(item: item_7, invoice: invoice_1, quantity: 1, unit_price: 5, status: 0)
+        invoice_item_10 = InvoiceItem.create!(item: item_10, invoice: invoice_1, quantity: 4, unit_price: 20, status: 0)
+        invoice_item_11 = InvoiceItem.create!(item: item_5, invoice: invoice_2, quantity: 10000, unit_price: 25, status: 0)
+        invoice_item_12 = InvoiceItem.create!(item: item_7, invoice: invoice_2, quantity: 10000, unit_price: 50, status: 0)
+        invoice_item_13 = InvoiceItem.create!(item: item_8, invoice: invoice_2, quantity: 10000, unit_price: 20, status: 0)
+        discount_1 = merchant_1.discounts.create!(percentage: 20, quantity_threshold: 20)
+        discount_2 = merchant_1.discounts.create!(percentage: 30, quantity_threshold: 40)
+
+        expect(invoice_1.invoice_items_with_discounts_applied.first.discount_percentage).to eq(100)
+        expect(invoice_1.invoice_items_with_discounts_applied.second.discount_percentage).to eq(80)
+        expect(invoice_1.invoice_items_with_discounts_applied.third.discount_percentage).to eq(100)
+        expect(invoice_1.invoice_items_with_discounts_applied.fourth.discount_percentage).to eq(60)
+        expect(invoice_1.invoice_items_with_discounts_applied.fifth.discount_percentage).to eq(60)
+      end
+    end
+
     describe '.discounted_revenue' do
       it 'returns the revenue of some invoice including discounts' do
         merchant_1 = Merchant.create!(name: "Jim's Rare Guitars")

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -200,13 +200,15 @@ RSpec.describe Invoice, type: :model do
         invoice_item_12 = InvoiceItem.create!(item: item_7, invoice: invoice_2, quantity: 10000, unit_price: 50, status: 0)
         invoice_item_13 = InvoiceItem.create!(item: item_8, invoice: invoice_2, quantity: 10000, unit_price: 20, status: 0)
         discount_1 = merchant_1.discounts.create!(percentage: 20, quantity_threshold: 20)
-        discount_2 = merchant_1.discounts.create!(percentage: 30, quantity_threshold: 40)
+        discount_2 = merchant_1.discounts.create!(percentage: 40, quantity_threshold: 30)
 
-        expect(invoice_1.invoice_items_with_discounts_applied.first.discount_percentage).to eq(100)
-        expect(invoice_1.invoice_items_with_discounts_applied.second.discount_percentage).to eq(80)
-        expect(invoice_1.invoice_items_with_discounts_applied.third.discount_percentage).to eq(100)
-        expect(invoice_1.invoice_items_with_discounts_applied.fourth.discount_percentage).to eq(60)
-        expect(invoice_1.invoice_items_with_discounts_applied.fifth.discount_percentage).to eq(60)
+        invoice_1.apply_discounts
+        
+        expect(invoice_1.invoice_items.first.discount_percentage).to eq(100)
+        expect(invoice_1.invoice_items.second.discount_percentage).to eq(80)
+        expect(invoice_1.invoice_items.third.discount_percentage).to eq(100)
+        expect(invoice_1.invoice_items.fourth.discount_percentage).to eq(60)
+        expect(invoice_1.invoice_items.fifth.discount_percentage).to eq(60)
       end
     end
 

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe Invoice, type: :model do
       end
     end
 
-    describe '.invoice_items_with_discounts_applied' do
+    describe '.apply_discounts' do
       it 'returns all invoice items with discounts applied to their discount_percentages if applicable' do
         merchant_1 = Merchant.create!(name: "Jim's Rare Guitars")
         item_1 = merchant_1.items.create!(name: "1959 Gibson Les Paul",
@@ -203,7 +203,7 @@ RSpec.describe Invoice, type: :model do
         discount_2 = merchant_1.discounts.create!(percentage: 40, quantity_threshold: 30)
 
         invoice_1.apply_discounts
-        
+
         expect(invoice_1.invoice_items.first.discount_percentage).to eq(100)
         expect(invoice_1.invoice_items.second.discount_percentage).to eq(80)
         expect(invoice_1.invoice_items.third.discount_percentage).to eq(100)
@@ -263,7 +263,7 @@ RSpec.describe Invoice, type: :model do
         invoice_item_12 = InvoiceItem.create!(item: item_7, invoice: invoice_2, quantity: 10000, unit_price: 50, status: 0)
         invoice_item_13 = InvoiceItem.create!(item: item_8, invoice: invoice_2, quantity: 10000, unit_price: 20, status: 0)
         discount_1 = merchant_1.discounts.create!(percentage: 20, quantity_threshold: 20)
-        discount_2 = merchant_1.discounts.create!(percentage: 30, quantity_threshold: 40)
+        discount_2 = merchant_1.discounts.create!(percentage: 40, quantity_threshold: 30)
 
         expect(invoice_1.discounted_revenue).to eq(1200)
       end


### PR DESCRIPTION
This branch accomplishes the following:

-creates an `invoice` model instance method `apply_discounts` which reduces each invoice_item's `discount_percentage` attribute by the `percentage` of the greatest available applicable discount 
-creates an `invoice` model instance method `discounted_revenue` which calculates the discounted revenue for a given invoice after discounts have been applied 
-displays an invoice's `discounted_revenue` on its `merchant_invoices#show` page