### PR TITLE
Invoice item discount link

### DIFF
--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -22,4 +22,10 @@ class InvoiceItem < ApplicationRecord
   def belongs_to_merchant(merchant_id)
     item.merchant_id == merchant_id.to_i
   end
+
+  def applied_discount
+    discounts.order(percentage: :desc).find do |discount|
+      discount.quantity_threshold <= quantity
+    end
+  end
 end

--- a/app/views/merchant_invoices/show.html.erb
+++ b/app/views/merchant_invoices/show.html.erb
@@ -22,6 +22,9 @@ Revenue after Discounts: $<%= "%.2f" % (@invoice.discounted_revenue.to_f/100).tr
       <%= form.select(:status, options_for_select([['Pending', :pending], ['Packaged', :packaged], ['Shipped', :shipped]], invoice_item.status)) %>
       <%= form.submit "Update Item Status" %>
     <% end %>
+    <% if invoice_item.applied_discount %>
+      <%= link_to "View Applied Bulk Discount", "/merchants/#{@merchant.id}/discounts/#{invoice_item.applied_discount.id}" %>
+    <% end %>
   <% end %>
 </div>
 <% end %>

--- a/spec/features/merchant_invoices/show_spec.rb
+++ b/spec/features/merchant_invoices/show_spec.rb
@@ -228,6 +228,40 @@ RSpec.describe 'the merchant invoice show page' do
       it 'i see the discounted revenue for the invoice' do
         expect(page).to have_content("Revenue after Discounts: $12.00")
       end
+
+      it 'next to each invoice_item, i see a link to the show page for the bulk discount that was applied to it' do
+        within "#item-#{@invoice_item_1.id}" do
+          expect(page).not_to have_link("View Applied Bulk Discount")
+        end
+        within "#item-#{@invoice_item_2.id}" do
+          expect(page).to have_link("View Applied Bulk Discount")
+        end
+        within "#item-#{@invoice_item_3.id}" do
+          expect(page).not_to have_link("View Applied Bulk Discount")
+        end
+        within "#item-#{@invoice_item_4.id}" do
+          expect(page).to have_link("View Applied Bulk Discount")
+        end
+        within "#item-#{@invoice_item_5.id}" do
+          expect(page).to have_link("View Applied Bulk Discount")
+        end
+      end
+
+      it 'if i click one of the invoice items links, it takes me to that bulk discounts show page' do
+        within "#item-#{@invoice_item_5.id}" do
+          click_link("View Applied Bulk Discount")
+        end
+
+        expect(current_path).to eq("/merchants/#{@merchant_1.id}/discounts/#{@discount_2.id}")
+
+        visit "/merchants/#{@merchant_1.id}/invoices/#{@invoice_1.id}"
+
+        within "#item-#{@invoice_item_2.id}" do
+          click_link("View Applied Bulk Discount")
+        end
+
+        expect(current_path).to eq("/merchants/#{@merchant_1.id}/discounts/#{@discount_1.id}")
+      end
     end
   end
 end

--- a/spec/models/invoice_item_spec.rb
+++ b/spec/models/invoice_item_spec.rb
@@ -78,16 +78,16 @@ RSpec.describe InvoiceItem, type: :model do
         discount_1 = merchant_1.discounts.create!(percentage: 20, quantity_threshold: 20)
         discount_2 = merchant_1.discounts.create!(percentage: 40, quantity_threshold: 30)
 
-        expect(invoice_item_1.applied_discount_id).to eq(nil)
-        expect(invoice_item_2.applied_discount_id).to eq(discount_1.id)
-        expect(invoice_item_3.applied_discount_id).to eq(nil)
-        expect(invoice_item_4.applied_discount_id).to eq(discount_2.id)
-        expect(invoice_item_5.applied_discount_id).to eq(discount_2.id)
-        expect(invoice_item_6.applied_discount_id).to eq(nil)
-        expect(invoice_item_7.applied_discount_id).to eq(nil)
-        expect(invoice_item_8.applied_discount_id).to eq(nil)
-        expect(invoice_item_9.applied_discount_id).to eq(nil)
-        expect(invoice_item_10.applied_discount_id).to eq(nil)
+        expect(invoice_item_1.applied_discount).to eq(nil)
+        expect(invoice_item_2.applied_discount).to eq(discount_1)
+        expect(invoice_item_3.applied_discount).to eq(nil)
+        expect(invoice_item_4.applied_discount).to eq(discount_2)
+        expect(invoice_item_5.applied_discount).to eq(discount_2)
+        expect(invoice_item_6.applied_discount).to eq(nil)
+        expect(invoice_item_7.applied_discount).to eq(nil)
+        expect(invoice_item_8.applied_discount).to eq(nil)
+        expect(invoice_item_9.applied_discount).to eq(nil)
+        expect(invoice_item_10.applied_discount).to eq(nil)
       end
     end
   end

--- a/spec/models/invoice_item_spec.rb
+++ b/spec/models/invoice_item_spec.rb
@@ -23,4 +23,72 @@ RSpec.describe InvoiceItem, type: :model do
       expect(InvoiceItem.total_revenue).to eq(2200)
     end
   end
+
+  describe 'instance methods' do
+    describe '.applied_discount_id' do
+      it 'returns the id of the discount applied to it' do
+        merchant_1 = Merchant.create!(name: "Jim's Rare Guitars")
+        item_1 = merchant_1.items.create!(name: "1959 Gibson Les Paul",
+                                        description: "Tobacco Burst Finish, Rosewood Fingerboard",
+                                        unit_price: 25000)
+        item_2 = merchant_1.items.create!(name: "1954 Fender Stratocaster",
+                                        description: "Seafoam Green Finish, Maple Fingerboard",
+                                        unit_price: 10000)
+        item_3 = merchant_1.items.create!(name: "1968 Gibson SG",
+                                        description: "Cherry Red Finish, Rosewood Fingerboard",
+                                        unit_price: 400)
+        item_4 = merchant_1.items.create!(name: "1984 Gibson Les Paul",
+                                        description: "Sunburst Finish, Maple Fingerboard",
+                                        unit_price: 600)
+        item_5 = merchant_1.items.create!(name: "1991 Gibson Les Paul",
+                                        description: "Sunburst Finish, Maple Fingerboard",
+                                        unit_price: 900)
+        item_6 = merchant_1.items.create!(name: "1993 Gibson Les Paul",
+                                        description: "Sunburst Finish, Maple Fingerboard",
+                                        unit_price: 700)
+        item_7 = merchant_1.items.create!(name: "2004 Gibson Les Paul",
+                                        description: "Sunburst Finish, Maple Fingerboard",
+                                        unit_price: 200)
+        item_8 = merchant_1.items.create!(name: "1997 Gibson Les Paul",
+                                        description: "Sunburst Finish, Maple Fingerboard",
+                                        unit_price: 100)
+        item_9 = merchant_1.items.create!(name: "1996 Gibson Les Paul",
+                                        description: "Sunburst Finish, Maple Fingerboard",
+                                        unit_price: 100)
+        item_10 = merchant_1.items.create!(name: "1975 Gibson Les Paul",
+                                        description: "Sunburst Finish, Maple Fingerboard",
+                                        unit_price: 400)
+        customer_1 = Customer.create!(first_name: "Guthrie", last_name: "Govan")
+
+        invoice_1 = customer_1.invoices.create!(status: 1)
+        invoice_2 = customer_1.invoices.create!(status: 0)
+        invoice_item_1 = InvoiceItem.create!(item: item_1, invoice: invoice_1, quantity: 1, unit_price: 5, status: 0)
+        invoice_item_2 = InvoiceItem.create!(item: item_9, invoice: invoice_1, quantity: 20, unit_price: 10, status: 0)
+        invoice_item_3 = InvoiceItem.create!(item: item_2, invoice: invoice_1, quantity: 10, unit_price: 20, status: 0)
+        invoice_item_4 = InvoiceItem.create!(item: item_4, invoice: invoice_1, quantity: 30, unit_price: 5, status: 0)
+        invoice_item_5 = InvoiceItem.create!(item: item_3, invoice: invoice_1, quantity: 35, unit_price: 10, status: 0)
+        invoice_item_6 = InvoiceItem.create!(item: item_5, invoice: invoice_1, quantity: 10, unit_price: 25, status: 0)
+        invoice_item_7 = InvoiceItem.create!(item: item_6, invoice: invoice_1, quantity: 5, unit_price: 10, status: 0)
+        invoice_item_8 = InvoiceItem.create!(item: item_8, invoice: invoice_1, quantity: 10, unit_price: 15, status: 0)
+        invoice_item_9 = InvoiceItem.create!(item: item_7, invoice: invoice_1, quantity: 1, unit_price: 5, status: 0)
+        invoice_item_10 = InvoiceItem.create!(item: item_10, invoice: invoice_1, quantity: 4, unit_price: 20, status: 0)
+        invoice_item_11 = InvoiceItem.create!(item: item_5, invoice: invoice_2, quantity: 10000, unit_price: 25, status: 0)
+        invoice_item_12 = InvoiceItem.create!(item: item_7, invoice: invoice_2, quantity: 10000, unit_price: 50, status: 0)
+        invoice_item_13 = InvoiceItem.create!(item: item_8, invoice: invoice_2, quantity: 10000, unit_price: 20, status: 0)
+        discount_1 = merchant_1.discounts.create!(percentage: 20, quantity_threshold: 20)
+        discount_2 = merchant_1.discounts.create!(percentage: 40, quantity_threshold: 30)
+
+        expect(invoice_item_1.applied_discount_id).to eq(nil)
+        expect(invoice_item_2.applied_discount_id).to eq(discount_1.id)
+        expect(invoice_item_3.applied_discount_id).to eq(nil)
+        expect(invoice_item_4.applied_discount_id).to eq(discount_2.id)
+        expect(invoice_item_5.applied_discount_id).to eq(discount_2.id)
+        expect(invoice_item_6.applied_discount_id).to eq(nil)
+        expect(invoice_item_7.applied_discount_id).to eq(nil)
+        expect(invoice_item_8.applied_discount_id).to eq(nil)
+        expect(invoice_item_9.applied_discount_id).to eq(nil)
+        expect(invoice_item_10.applied_discount_id).to eq(nil)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This branch accomplishes the following: 

-creates `invoice_item` model `applied_discount` instance method that returns the discount applied to that `invoice_item` if applicable
-displays a link to the applied discount's `merchant_discounts#show` page for all `invoice_items` displayed on the `merchant_invoices#show` page to which a discount was applied