### PR TITLE
Merchant invoice revenue edge cases

### DIFF
--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -11,6 +11,33 @@ class InvoiceItem < ApplicationRecord
     sum('unit_price * quantity')
   end
 
+  def self.total_revenue_for_invoice(invoice_id)
+    sorted_invoices = self.where(invoice_id: invoice_id)
+    sorted_invoices.sum('invoice_items.quantity * invoice_items.unit_price')
+  end
+
+  def self.apply_discounts_for_invoice(invoice_id)
+    sorted_invoice_items = self.where(invoice_id: invoice_id)
+    sorted_invoice_items.each do |invoice_item|
+      if invoice_item.invoice_id == invoice_id
+        invoice_item.discounts.distinct.order(percentage: :desc).each do |discount|
+          if discount.quantity_threshold <= invoice_item.quantity && invoice_item.discount_percentage == 100
+            invoice_item.update(discount_percentage: invoice_item.discount_percentage - discount.percentage)
+          end
+        end
+      end
+    end
+    sorted_invoice_items
+  end
+
+  def self.discounted_revenue_for_invoice(invoice_id)
+    total = 0
+    apply_discounts_for_invoice(invoice_id).each do |invoice_item|
+      total += ((invoice_item.unit_price * invoice_item.quantity) * (invoice_item.discount_percentage.to_f / 100))
+    end
+    total
+  end
+
   def invoice_dates
     invoice.created_at.strftime("%A, %B %d, %Y")
   end

--- a/app/views/merchant_invoices/show.html.erb
+++ b/app/views/merchant_invoices/show.html.erb
@@ -6,8 +6,8 @@ Created At: <%= @invoice.dates %>
 <br>
 Customer Name: <%= @invoice.full_name %>
 <br>
-Total Revenue: $<%= "%.2f" % (@invoice.total_revenue.to_f/100).truncate(2) %>
-Revenue after Discounts: $<%= "%.2f" % (@invoice.discounted_revenue.to_f/100).truncate(2) %>
+Total Revenue: $<%= "%.2f" % (@merchant.invoice_items.total_revenue_for_invoice(@invoice.id).to_f/100).truncate(2) %>
+Revenue after Discounts: $<%= "%.2f" % (@merchant.invoice_items.discounted_revenue_for_invoice(@invoice.id).to_f/100).truncate(2) %>
 <% @invoice.invoice_items.each do |invoice_item|%>
 <div id="item-<%= invoice_item.id %>">
   <% if invoice_item.belongs_to_merchant(@merchant.id) %>

--- a/spec/features/merchant_invoices/show_spec.rb
+++ b/spec/features/merchant_invoices/show_spec.rb
@@ -168,6 +168,7 @@ RSpec.describe 'the merchant invoice show page' do
     describe 'applying bulk discounts' do
       before :each do
         @merchant_1 = Merchant.create!(name: "Jim's Rare Guitars")
+        @merchant_2 = Merchant.create!(name: "Bill's Less Rare Guitars")
         @item_1 = @merchant_1.items.create!(name: "1959 Gibson Les Paul",
                                         description: "Tobacco Burst Finish, Rosewood Fingerboard",
                                         unit_price: 25000)
@@ -198,8 +199,13 @@ RSpec.describe 'the merchant invoice show page' do
         @item_10 = @merchant_1.items.create!(name: "1975 Gibson Les Paul",
                                         description: "Sunburst Finish, Maple Fingerboard",
                                         unit_price: 400)
+        @item_11 = @merchant_2.items.create!(name: "1975 Gibson Les Paul",
+                                        description: "Sunburst Finish, Maple Fingerboard",
+                                        unit_price: 400)
+        @item_12 = @merchant_2.items.create!(name: "1975 Gibson Les Paul",
+                                        description: "Sunburst Finish, Maple Fingerboard",
+                                        unit_price: 400)
         @customer_1 = Customer.create!(first_name: "Guthrie", last_name: "Govan")
-
         @invoice_1 = @customer_1.invoices.create!(status: 1)
         @invoice_2 = @customer_1.invoices.create!(status: 0)
         @invoice_item_1 = InvoiceItem.create!(item: @item_1, invoice: @invoice_1, quantity: 1, unit_price: 5, status: 0)
@@ -215,6 +221,8 @@ RSpec.describe 'the merchant invoice show page' do
         @invoice_item_11 = InvoiceItem.create!(item: @item_5, invoice: @invoice_2, quantity: 10000, unit_price: 25, status: 0)
         @invoice_item_12 = InvoiceItem.create!(item: @item_7, invoice: @invoice_2, quantity: 10000, unit_price: 50, status: 0)
         @invoice_item_13 = InvoiceItem.create!(item: @item_8, invoice: @invoice_2, quantity: 10000, unit_price: 20, status: 0)
+        @invoice_item_14 = InvoiceItem.create!(item: @item_11, invoice: @invoice_1, quantity: 10000, unit_price: 20, status: 0)
+        @invoice_item_15 = InvoiceItem.create!(item: @item_12, invoice: @invoice_1, quantity: 10000, unit_price: 20, status: 0)
         @discount_1 = @merchant_1.discounts.create!(percentage: 20, quantity_threshold: 20)
         @discount_2 = @merchant_1.discounts.create!(percentage: 40, quantity_threshold: 30)
 


### PR DESCRIPTION
This branch accomplishes the following: 

-adds additional edge case testing for the total and discounted revenue displays on a `merchant_invoices#show` page to ensure that only the given merchant's invoice_items and are included in the calculations and only for that invoice