### PR TITLE
Merchant revenue refactor

### DIFF
--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -42,4 +42,12 @@ class Merchant < ApplicationRecord
   def invoice_items_by_invoice(invoice_id)
     invoice_items.where(invoice_id: invoice_id)
   end
+
+  def total_revenue_for_invoice(invoice_id)
+    invoice_items_by_invoice(invoice_id).total_revenue
+  end
+
+  def discounted_revenue_for_invoice(invoice_id)
+    invoice_items_by_invoice(invoice_id).discounted_revenue
+  end
 end

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -1,6 +1,7 @@
 <h1>Invoice ID: <%= @invoice.id %></h1><hr>
 <p>Created at: <%= @invoice.created_at.strftime("%A, %B %d, %Y") %></p>
-<p>Customer: <%= @invoice.customer.first_name %> <%= @invoice.customer.last_name %></p>
+<p>Customer: <%= @invoice.customer_full_name %></p>
+
 <%= render 'form' %><hr>
 
 <h3>Items:</h3>

--- a/app/views/merchant_invoices/show.html.erb
+++ b/app/views/merchant_invoices/show.html.erb
@@ -2,8 +2,8 @@
 <h3>Invoice Status: <%= @invoice.status %></h3>
 <h3>Created At: <%= @invoice.created_at.strftime("%A, %B %d, %Y") %></h3>
 <h3>Customer Name: <%= @invoice.customer_full_name %></h3>
-<h3>Total Revenue: $<%= "%.2f" % (@merchant.invoice_items_by_invoice(@invoice.id).total_revenue.to_f/100).truncate(2) %></h3>
-<h3>Revenue after Bulk Discounts: $<%= "%.2f" % (@merchant.invoice_items_by_invoice(@invoice.id).discounted_revenue.to_f/100).truncate(2) %></h3>
+<h3>Total Revenue: $<%= "%.2f" % (@merchant.total_revenue_for_invoice(@invoice.id).to_f/100).truncate(2) %></h3>
+<h3>Revenue after Bulk Discounts: $<%= "%.2f" % (@merchant.discounted_revenue_for_invoice(@invoice.id).to_f/100).truncate(2) %></h3>
 <hr>
 
 <% @invoice.invoice_items.each do |invoice_item|%>

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -173,6 +173,136 @@ RSpec.describe Merchant, type: :model do
           expect(merchant_1.invoice_items_by_invoice(invoice_1.id)).to eq([invoice_item_1, invoice_item_3])
         end
       end
+
+      describe 'total_revenue_for_invoice' do
+        it 'returns the total revenue for all of the merchants invoice_items on some invoice' do
+          merchant_1 = Merchant.create!(name: "Jim's Rare Guitars")
+          merchant_2 = Merchant.create!(name: "Bill's Less Rare Guitars")
+          item_1 = merchant_1.items.create!(name: "1959 Gibson Les Paul",
+                                          description: "Tobacco Burst Finish, Rosewood Fingerboard",
+                                          unit_price: 25000)
+          item_2 = merchant_1.items.create!(name: "1954 Fender Stratocaster",
+                                          description: "Seafoam Green Finish, Maple Fingerboard",
+                                          unit_price: 10000)
+          item_3 = merchant_1.items.create!(name: "1968 Gibson SG",
+                                          description: "Cherry Red Finish, Rosewood Fingerboard",
+                                          unit_price: 400)
+          item_4 = merchant_1.items.create!(name: "1984 Gibson Les Paul",
+                                          description: "Sunburst Finish, Maple Fingerboard",
+                                          unit_price: 600)
+          item_5 = merchant_1.items.create!(name: "1991 Gibson Les Paul",
+                                          description: "Sunburst Finish, Maple Fingerboard",
+                                          unit_price: 900)
+          item_6 = merchant_1.items.create!(name: "1993 Gibson Les Paul",
+                                          description: "Sunburst Finish, Maple Fingerboard",
+                                          unit_price: 700)
+          item_7 = merchant_1.items.create!(name: "2004 Gibson Les Paul",
+                                          description: "Sunburst Finish, Maple Fingerboard",
+                                          unit_price: 200)
+          item_8 = merchant_1.items.create!(name: "1997 Gibson Les Paul",
+                                          description: "Sunburst Finish, Maple Fingerboard",
+                                          unit_price: 100)
+          item_9 = merchant_1.items.create!(name: "1996 Gibson Les Paul",
+                                          description: "Sunburst Finish, Maple Fingerboard",
+                                          unit_price: 100)
+          item_10 = merchant_1.items.create!(name: "1975 Gibson Les Paul",
+                                          description: "Sunburst Finish, Maple Fingerboard",
+                                          unit_price: 400)
+          item_11 = merchant_2.items.create!(name: "1975 Gibson Les Paul",
+                                          description: "Sunburst Finish, Maple Fingerboard",
+                                          unit_price: 400)
+          item_12 = merchant_2.items.create!(name: "1975 Gibson Les Paul",
+                                          description: "Sunburst Finish, Maple Fingerboard",
+                                          unit_price: 400)
+          customer_1 = Customer.create!(first_name: "Guthrie", last_name: "Govan")
+          invoice_1 = customer_1.invoices.create!(status: 1)
+          invoice_2 = customer_1.invoices.create!(status: 0)
+          invoice_item_1 = InvoiceItem.create!(item: item_1, invoice: invoice_1, quantity: 1, unit_price: 5, status: 0)
+          invoice_item_2 = InvoiceItem.create!(item: item_9, invoice: invoice_1, quantity: 20, unit_price: 10, status: 0)
+          invoice_item_3 = InvoiceItem.create!(item: item_2, invoice: invoice_1, quantity: 10, unit_price: 20, status: 0)
+          invoice_item_4 = InvoiceItem.create!(item: item_4, invoice: invoice_1, quantity: 30, unit_price: 5, status: 0)
+          invoice_item_5 = InvoiceItem.create!(item: item_3, invoice: invoice_1, quantity: 35, unit_price: 10, status: 0)
+          invoice_item_6 = InvoiceItem.create!(item: item_5, invoice: invoice_1, quantity: 10, unit_price: 25, status: 0)
+          invoice_item_7 = InvoiceItem.create!(item: item_6, invoice: invoice_1, quantity: 5, unit_price: 10, status: 0)
+          invoice_item_8 = InvoiceItem.create!(item: item_8, invoice: invoice_1, quantity: 10, unit_price: 15, status: 0)
+          invoice_item_9 = InvoiceItem.create!(item: item_7, invoice: invoice_1, quantity: 1, unit_price: 5, status: 0)
+          invoice_item_10 = InvoiceItem.create!(item: item_10, invoice: invoice_1, quantity: 4, unit_price: 20, status: 0)
+          invoice_item_11 = InvoiceItem.create!(item: item_5, invoice: invoice_2, quantity: 10000, unit_price: 25, status: 0)
+          invoice_item_12 = InvoiceItem.create!(item: item_7, invoice: invoice_2, quantity: 10000, unit_price: 50, status: 0)
+          invoice_item_13 = InvoiceItem.create!(item: item_8, invoice: invoice_2, quantity: 10000, unit_price: 20, status: 0)
+          invoice_item_14 = InvoiceItem.create!(item: item_11, invoice: invoice_1, quantity: 10000, unit_price: 20, status: 0)
+          invoice_item_15 = InvoiceItem.create!(item: item_12, invoice: invoice_1, quantity: 10000, unit_price: 20, status: 0)
+          bulk_discount_1 = merchant_1.bulk_discounts.create!(percentage: 20, quantity_threshold: 20)
+          bulk_discount_2 = merchant_1.bulk_discounts.create!(percentage: 40, quantity_threshold: 30)
+
+          expect(merchant_1.total_revenue_for_invoice(invoice_1.id)).to eq(1440)
+        end
+      end
+
+      describe 'discounted_revenue_for_invoice' do
+        it 'returns the discounted revenue for all of the merchants invoice_items on some invoice' do
+          merchant_1 = Merchant.create!(name: "Jim's Rare Guitars")
+          merchant_2 = Merchant.create!(name: "Bill's Less Rare Guitars")
+          item_1 = merchant_1.items.create!(name: "1959 Gibson Les Paul",
+                                          description: "Tobacco Burst Finish, Rosewood Fingerboard",
+                                          unit_price: 25000)
+          item_2 = merchant_1.items.create!(name: "1954 Fender Stratocaster",
+                                          description: "Seafoam Green Finish, Maple Fingerboard",
+                                          unit_price: 10000)
+          item_3 = merchant_1.items.create!(name: "1968 Gibson SG",
+                                          description: "Cherry Red Finish, Rosewood Fingerboard",
+                                          unit_price: 400)
+          item_4 = merchant_1.items.create!(name: "1984 Gibson Les Paul",
+                                          description: "Sunburst Finish, Maple Fingerboard",
+                                          unit_price: 600)
+          item_5 = merchant_1.items.create!(name: "1991 Gibson Les Paul",
+                                          description: "Sunburst Finish, Maple Fingerboard",
+                                          unit_price: 900)
+          item_6 = merchant_1.items.create!(name: "1993 Gibson Les Paul",
+                                          description: "Sunburst Finish, Maple Fingerboard",
+                                          unit_price: 700)
+          item_7 = merchant_1.items.create!(name: "2004 Gibson Les Paul",
+                                          description: "Sunburst Finish, Maple Fingerboard",
+                                          unit_price: 200)
+          item_8 = merchant_1.items.create!(name: "1997 Gibson Les Paul",
+                                          description: "Sunburst Finish, Maple Fingerboard",
+                                          unit_price: 100)
+          item_9 = merchant_1.items.create!(name: "1996 Gibson Les Paul",
+                                          description: "Sunburst Finish, Maple Fingerboard",
+                                          unit_price: 100)
+          item_10 = merchant_1.items.create!(name: "1975 Gibson Les Paul",
+                                          description: "Sunburst Finish, Maple Fingerboard",
+                                          unit_price: 400)
+          item_11 = merchant_2.items.create!(name: "1975 Gibson Les Paul",
+                                          description: "Sunburst Finish, Maple Fingerboard",
+                                          unit_price: 400)
+          item_12 = merchant_2.items.create!(name: "1975 Gibson Les Paul",
+                                          description: "Sunburst Finish, Maple Fingerboard",
+                                          unit_price: 400)
+          customer_1 = Customer.create!(first_name: "Guthrie", last_name: "Govan")
+          invoice_1 = customer_1.invoices.create!(status: 1)
+          invoice_2 = customer_1.invoices.create!(status: 0)
+          invoice_item_1 = InvoiceItem.create!(item: item_1, invoice: invoice_1, quantity: 1, unit_price: 5, status: 0)
+          invoice_item_2 = InvoiceItem.create!(item: item_9, invoice: invoice_1, quantity: 20, unit_price: 10, status: 0)
+          invoice_item_3 = InvoiceItem.create!(item: item_2, invoice: invoice_1, quantity: 10, unit_price: 20, status: 0)
+          invoice_item_4 = InvoiceItem.create!(item: item_4, invoice: invoice_1, quantity: 30, unit_price: 5, status: 0)
+          invoice_item_5 = InvoiceItem.create!(item: item_3, invoice: invoice_1, quantity: 35, unit_price: 10, status: 0)
+          invoice_item_6 = InvoiceItem.create!(item: item_5, invoice: invoice_1, quantity: 10, unit_price: 25, status: 0)
+          invoice_item_7 = InvoiceItem.create!(item: item_6, invoice: invoice_1, quantity: 5, unit_price: 10, status: 0)
+          invoice_item_8 = InvoiceItem.create!(item: item_8, invoice: invoice_1, quantity: 10, unit_price: 15, status: 0)
+          invoice_item_9 = InvoiceItem.create!(item: item_7, invoice: invoice_1, quantity: 1, unit_price: 5, status: 0)
+          invoice_item_10 = InvoiceItem.create!(item: item_10, invoice: invoice_1, quantity: 4, unit_price: 20, status: 0)
+          invoice_item_11 = InvoiceItem.create!(item: item_5, invoice: invoice_2, quantity: 10000, unit_price: 25, status: 0)
+          invoice_item_12 = InvoiceItem.create!(item: item_7, invoice: invoice_2, quantity: 10000, unit_price: 50, status: 0)
+          invoice_item_13 = InvoiceItem.create!(item: item_8, invoice: invoice_2, quantity: 10000, unit_price: 20, status: 0)
+          invoice_item_14 = InvoiceItem.create!(item: item_11, invoice: invoice_1, quantity: 10000, unit_price: 20, status: 0)
+          invoice_item_15 = InvoiceItem.create!(item: item_12, invoice: invoice_1, quantity: 10000, unit_price: 20, status: 0)
+          bulk_discount_1 = merchant_1.bulk_discounts.create!(percentage: 20, quantity_threshold: 20)
+          bulk_discount_2 = merchant_1.bulk_discounts.create!(percentage: 40, quantity_threshold: 30)
+
+          expect(merchant_1.discounted_revenue_for_invoice(invoice_1.id)).to eq(1200)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This branch accomplishes the following: 

-creates and tests two `merchant` model instance methods: `total_revenue_for_invoice` and `discounted_revenue_for_invoice`, both of which taken argument of some invoice_id and calculates the total revenue and discounted revenue for all of that merchant's invoice_items on that invoice passed in as an argument
-refactors the `merchant_invoices#show` page to use these two methods to reduce chaining